### PR TITLE
3-2 테스트코드

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ app.post('/api/events', async (req, res) => {
 
 app.put('/api/events/:id', async (req, res) => {
   const events = await getEvents();
-  const { id } = req.params;
+  const id = req.params.id;
   const eventIndex = events.events.findIndex((event) => event.id === id);
   if (eventIndex > -1) {
     const newEvents = [...events.events];
@@ -59,12 +59,78 @@ app.put('/api/events/:id', async (req, res) => {
 
 app.delete('/api/events/:id', async (req, res) => {
   const events = await getEvents();
-  const { id } = req.params;
+  const id = req.params.id;
 
   fs.writeFileSync(
     `${__dirname}/src/__mocks__/response/realEvents.json`,
     JSON.stringify({
       events: events.events.filter((event) => event.id !== id),
+    })
+  );
+
+  res.status(204).send();
+});
+
+app.post('/api/events-list', async (req, res) => {
+  const events = await getEvents();
+  const repeatId = randomUUID();
+  const newEvents = req.body.events.map((event) => {
+    const isRepeatEvent = event.repeat.type !== 'none';
+    return {
+      id: randomUUID(),
+      ...event,
+      repeat: {
+        ...event.repeat,
+        id: isRepeatEvent ? repeatId : undefined,
+      },
+    };
+  });
+
+  fs.writeFileSync(
+    `${__dirname}/src/__mocks__/response/realEvents.json`,
+    JSON.stringify({
+      events: [...events.events, ...newEvents],
+    })
+  );
+
+  res.status(201).json(newEvents);
+});
+
+app.put('/api/events-list', async (req, res) => {
+  const events = await getEvents();
+  let isUpdated = false;
+
+  const newEvents = [...events.events];
+  req.body.events.forEach((event) => {
+    const eventIndex = events.events.findIndex((target) => target.id === event.id);
+    if (eventIndex > -1) {
+      isUpdated = true;
+      newEvents[eventIndex] = { ...events.events[eventIndex], ...event };
+    }
+  });
+
+  if (isUpdated) {
+    fs.writeFileSync(
+      `${__dirname}/src/__mocks__/response/realEvents.json`,
+      JSON.stringify({
+        events: newEvents,
+      })
+    );
+
+    res.json(events.events);
+  } else {
+    res.status(404).send('Event not found');
+  }
+});
+
+app.delete('/api/events-list', async (req, res) => {
+  const events = await getEvents();
+  const newEvents = events.events.filter((event) => !req.body.eventIds.includes(event.id)); // ? ids를 전달하면 해당 아이디를 기준으로 events에서 제거
+
+  fs.writeFileSync(
+    `${__dirname}/src/__mocks__/response/realEvents.json`,
+    JSON.stringify({
+      events: newEvents,
     })
   );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,21 @@ const notificationOptions = [
   { value: 1440, label: '1일 전' },
 ];
 
+const getRepeatTypeLabel = (type: string) => {
+  switch (type) {
+    case 'daily':
+      return '매일';
+    case 'weekly':
+      return '매주';
+    case 'monthly':
+      return '매월';
+    case 'yearly':
+      return '매년';
+    default:
+      return '없음';
+  }
+};
+
 function App() {
   const {
     title,
@@ -77,11 +92,11 @@ function App() {
     isRepeating,
     setIsRepeating,
     repeatType,
-    // setRepeatType,
+    setRepeatType,
     repeatInterval,
-    // setRepeatInterval,
+    setRepeatInterval,
     repeatEndDate,
-    // setRepeatEndDate,
+    setRepeatEndDate,
     notificationTime,
     setNotificationTime,
     startTimeError,
@@ -94,8 +109,9 @@ function App() {
     editEvent,
   } = useEventForm();
 
-  const { events, saveEvent, deleteEvent } = useEventOperations(Boolean(editingEvent), () =>
-    setEditingEvent(null)
+  const { events, saveEvent, deleteEvent, createRepeatEvent } = useEventOperations(
+    Boolean(editingEvent),
+    () => setEditingEvent(null)
   );
 
   const { notifications, notifiedEvents, setNotifications } = useNotifications(events);
@@ -420,6 +436,53 @@ function App() {
               label="반복 일정"
             />
           </FormControl>
+          {isRepeating && (
+            <Stack>
+              <FormControl fullWidth>
+                <FormLabel htmlFor="description">반복 유형</FormLabel>
+                <Select
+                  id="repeatType"
+                  size="small"
+                  value={repeatType}
+                  onChange={(e) => setRepeatType(e.target.value)}
+                >
+                  {[
+                    { label: '매일', value: 'daily' },
+                    { label: '매주', value: 'weekly' },
+                    { label: '매월', value: 'monthly' },
+                    { label: '매년', value: 'yearly' },
+                  ].map((option) => (
+                    <MenuItem key={option.value} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Stack direction="row" spacing={2}>
+                <FormControl fullWidth>
+                  <FormLabel htmlFor="repeat-interval">반복 간격</FormLabel>
+                  <TextField
+                    id="repeat-interval"
+                    size="small"
+                    type="number"
+                    value={repeatInterval}
+                    onChange={(e) => setRepeatInterval(Number(e.target.value))}
+                    slotProps={{ htmlInput: { min: 1, max: 10 } }}
+                  />
+                </FormControl>
+                <FormControl fullWidth>
+                  <FormLabel htmlFor="repeat-end-date">반복 종료일</FormLabel>
+                  <TextField
+                    id="repeat-end-date"
+                    size="small"
+                    type="date"
+                    value={repeatEndDate}
+                    onChange={(e) => setRepeatEndDate(e.target.value)}
+                  />
+                </FormControl>
+              </Stack>
+            </Stack>
+          )}
 
           <FormControl fullWidth>
             <FormLabel htmlFor="notification">알림 설정</FormLabel>
@@ -436,46 +499,6 @@ function App() {
               ))}
             </Select>
           </FormControl>
-
-          {/* ! 반복은 8주차 과제에 포함됩니다. 구현하고 싶어도 참아주세요~ */}
-          {/* {isRepeating && (
-            <Stack spacing={2}>
-              <FormControl fullWidth>
-                <FormLabel>반복 유형</FormLabel>
-                <Select
-                  size="small"
-                  value={repeatType}
-                  onChange={(e) => setRepeatType(e.target.value as RepeatType)}
-                >
-                  <MenuItem value="daily">매일</MenuItem>
-                  <MenuItem value="weekly">매주</MenuItem>
-                  <MenuItem value="monthly">매월</MenuItem>
-                  <MenuItem value="yearly">매년</MenuItem>
-                </Select>
-              </FormControl>
-              <Stack direction="row" spacing={2}>
-                <FormControl fullWidth>
-                  <FormLabel>반복 간격</FormLabel>
-                  <TextField
-                    size="small"
-                    type="number"
-                    value={repeatInterval}
-                    onChange={(e) => setRepeatInterval(Number(e.target.value))}
-                    slotProps={{ htmlInput: { min: 1 } }}
-                  />
-                </FormControl>
-                <FormControl fullWidth>
-                  <FormLabel>반복 종료일</FormLabel>
-                  <TextField
-                    size="small"
-                    type="date"
-                    value={repeatEndDate}
-                    onChange={(e) => setRepeatEndDate(e.target.value)}
-                  />
-                </FormControl>
-              </Stack>
-            </Stack>
-          )} */}
 
           <Button
             data-testid="event-submit-button"

--- a/src/__tests__/unit/generateRepeatEvents.spec.ts
+++ b/src/__tests__/unit/generateRepeatEvents.spec.ts
@@ -1,0 +1,52 @@
+import { Event } from '../../types';
+import { generateRepeatEvents } from '../../utils/generateRepeatEvents';
+
+// 1단계: 기본 동작 정의
+// 요구사항 1.1 - 반복하지 않는 일정 처리
+
+// 반복 유형이 'none'인 경우, 원본 이벤트 하나만 결과로 나와야 합니다
+// 입력한 이벤트가 그대로 배열에 담겨 반환되는지 확인하세요
+
+// 요구사항 1.2 - 종료일이 없는 경우의 기본 동작
+
+// 반복 종료일이 지정되지 않았다면, 시스템은 합리적인 최대 날짜까지만 생성해야 합니다
+// 무한정 생성되는 것을 방지하기 위한 안전장치가 필요합니다
+// 생성된 마지막 이벤트의 날짜가 예상한 최대 날짜와 일치하는지 확인하세요
+
+describe('반복 유형 & 반복 종료일이 없는 경우', () => {
+  it('반복이 되지않는 이벤트는 단일로 배열에 담겨 반환된다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '단일 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-06-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'none', interval: 0 },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+
+    expect(result).toEqual([event]);
+  });
+
+  it('반복 종료일이 없는 이벤트는 최대 6월 30일까지만 생성한다.', () => {
+    const event: Event = {
+      id: '2',
+      title: '매일 반복 이벤트',
+      startTime: '09:00',
+      endTime: '10:00',
+      date: '2024-06-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '운동',
+      repeat: { type: 'daily', interval: 1 },
+      notificationTime: 30,
+    };
+    const result = generateRepeatEvents(event);
+    const last = result[result.length - 1];
+    expect(Date.parse(last.date)).toBe(Date.parse('2024-06-30')); // new Date가 아닌 Date.parse 사용
+  });
+});

--- a/src/__tests__/unit/generateRepeatEvents.spec.ts
+++ b/src/__tests__/unit/generateRepeatEvents.spec.ts
@@ -147,8 +147,9 @@ describe('주간 반복', () => {
     const result = generateRepeatEvents(event);
     expect(result).toHaveLength(3);
     expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2024-01-15', '2024-01-29']);
-  }
+  });
 });
+
 // 4단계: 월간 반복 구현
 // 요구사항 4.1 - 매월 같은 날짜에 반복
 
@@ -255,7 +256,7 @@ describe('연간 반복', () => {
     const result = generateRepeatEvents(event);
     expect(result).toHaveLength(3);
     expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2025-01-01', '2026-01-01']);
-  })
+  });
 
   it('2024-01-01부터 2년마다 같은 날짜에 반복되는 일정은 2024-01-01, 2026-01-01, 2028-01-01에 동일한 일정이 있다.', () => {
     const event: Event = {
@@ -273,7 +274,7 @@ describe('연간 반복', () => {
     const result = generateRepeatEvents(event);
     expect(result).toHaveLength(3);
     expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2026-01-01', '2028-01-01']);
-  })
+  });
 
   it('2024-02-29부터 1년마다 같은 날짜에 반복되는 일정은 2024-02-29, 2028-02-29에 동일한 일정이 있다.', () => {
     const event: Event = {
@@ -291,8 +292,8 @@ describe('연간 반복', () => {
     const result = generateRepeatEvents(event);
     expect(result).toHaveLength(2);
     expect(result.map((e) => e.date)).toEqual(['2024-02-29', '2028-02-29']);
-  })
-})
+  });
+});
 
 // 6단계: 예외 상황 처리
 // 요구사항 6.1 - 간격이 0인 경우
@@ -301,7 +302,7 @@ describe('연간 반복', () => {
 // 이런 경우 반복하지 않고 원본 이벤트 하나만 반환해야 합니다
 
 describe('예외 상황 처리', () => {
-  it('반복 간격이 0인 경우, 기존에 이벤트 하나만 반환된다.',() => {
+  it('반복 간격이 0인 경우, 기존에 이벤트 하나만 반환된다.', () => {
     const event: Event = {
       id: '1',
       title: '반복 간격이 0인 이벤트',
@@ -317,5 +318,5 @@ describe('예외 상황 처리', () => {
     const result = generateRepeatEvents(event);
     expect(result).toHaveLength(1);
     expect(result).toEqual([event]);
-  })
-})
+  });
+});

--- a/src/__tests__/unit/generateRepeatEvents.spec.ts
+++ b/src/__tests__/unit/generateRepeatEvents.spec.ts
@@ -50,3 +50,272 @@ describe('반복 유형 & 반복 종료일이 없는 경우', () => {
     expect(Date.parse(last.date)).toBe(Date.parse('2024-06-30')); // new Date가 아닌 Date.parse 사용
   });
 });
+
+// 2단계: 일간 반복 구현
+// 요구사항 2.1 - 매일 반복
+
+// 시작일부터 종료일까지 하루도 빠짐없이 이벤트가 생성되어야 합니다
+// 예: 1월 1일 ~ 1월 3일 매일 반복 → 1일, 2일, 3일 총 3개
+
+// 요구사항 2.2 - N일 간격 반복
+
+// 지정된 간격만큼 건너뛰며 생성되어야 합니다
+// 예: 1월 1일부터 2일 간격으로 반복 → 1일, 3일, 5일...
+// 간격이 2라면 하루 건너뛰고 생성되는 개념입니다
+
+describe('일간 반복', () => {
+  it('2024-01-01부터 3일 반복되는 일정은 2024-01-01, 2024-01-02, 2024-01-03에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '3일간 매일 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'daily', interval: 1, endDate: '2024-01-03' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2024-01-02', '2024-01-03']);
+  });
+
+  it('2024-01-01부터 2일 간격으로 반복되는 일정은 2024-01-01, 2024-01-03, 2024-01-05에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '2일간격으로 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'daily', interval: 2, endDate: '2024-01-05' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2024-01-03', '2024-01-05']);
+  });
+});
+
+// 3단계: 주간 반복 구현
+// 요구사항 3.1 - 매주 반복 (같은 요일)
+
+// 시작일과 같은 요일에 이벤트가 생성되어야 합니다
+// 정확히 7일 간격으로 생성되는지 확인하세요
+// 예: 1월 1일(월)부터 매주 → 1일, 8일, 15일 (모두 월요일)
+
+// 요구사항 3.2 - N주 간격 반복
+
+// 지정된 주 수만큼 건너뛰며 생성되어야 합니다
+// 예: 2주 간격이면 14일씩 더해지는 개념입니다
+describe('주간 반복', () => {
+  it('2024-01-01부터 일주일 간격으로 반복되는 일정은 2024-01-01, 2024-01-08, 2024-01-15에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '일주일 간격으로 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'weekly', interval: 1, endDate: '2024-01-15' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2024-01-08', '2024-01-15']);
+  });
+
+  it('2024-01-01부터 2주일 간격으로 반복되는 일정은 2024-01-01, 2024-01-15, 2024-01-29에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '이주일 간격으로 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'weekly', interval: 2, endDate: '2024-01-29' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2024-01-15', '2024-01-29']);
+  }
+});
+// 4단계: 월간 반복 구현
+// 요구사항 4.1 - 매월 같은 날짜에 반복
+
+// 시작일의 일(day) 값이 유지되어야 합니다
+// 예: 1월 15일부터 매월 → 1월 15일, 2월 15일, 3월 15일
+
+// 요구사항 4.2 - N개월 간격 반복
+
+// 지정된 개월 수만큼 건너뛰며 생성되어야 합니다
+// 예: 2개월 간격 → 1월 15일, 3월 15일, 5월 15일
+
+// 요구사항 4.3 - 월말 날짜의 특수 처리
+
+// 1월 31일을 기준으로 매월 반복할 때, 2월에는 어떻게 될까요?
+// 해당 월에 존재하지 않는 날짜는 건너뛰어야 합니다
+// 예: 1월 31일 매월 반복 → 1월 31일, (2월 건너뜀), 3월 31일
+describe('월간 반복', () => {
+  it('2024-01-01부터 매월 같은 날짜에 반복되는 일정은 2024-01-01, 2024-02-01, 2024-03-01에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '한달 간격으로 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'monthly', interval: 1, endDate: '2024-03-01' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2024-02-01', '2024-03-01']);
+  });
+
+  it('2024-01-01부터 2달 간격으로 같은 날짜에 반복되는 일정은 2024-01-01, 2024-03-01, 2024-05-01에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '두달 간격으로 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'monthly', interval: 2, endDate: '2024-05-01' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2024-03-01', '2024-05-01']);
+  });
+
+  it('2024-01-31부터 매월 반복되는 일정은 2024-01-31, 2024-03-31에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '한달 간격으로 특수 날짜 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-31',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'monthly', interval: 1, endDate: '2024-03-31' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-31', '2024-03-31']);
+  });
+});
+
+// 5단계: 연간 반복 구현
+// 요구사항 5.1 - 매년 같은 날짜에 반복
+
+// 월과 일이 모두 유지되어야 합니다
+// 예: 2024년 3월 15일부터 매년 → 2024/3/15, 2025/3/15, 2026/3/15
+
+// 요구사항 5.2 - N년 간격 반복
+
+// 지정된 연도만큼 건너뛰며 생성되어야 합니다
+// 예: 2년 간격 → 2024년, 2026년, 2028년
+
+// 요구사항 5.3 - 윤년의 2월 29일 처리
+
+// 2월 29일은 4년마다만 존재합니다
+// 평년(2025, 2026, 2027)에는 2월 29일이 없으므로 건너뛰어야 합니다
+// 다음 윤년(2028)에만 다시 생성되어야 합니다
+
+describe('연간 반복', () => {
+  it('2024-01-01부터 매년 같은 날짜에 반복되는 일정은 2024-01-01, 2025-01-01, 2026-01-01에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '매년 같은 날짜 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'yearly', interval: 1, endDate: '2026-01-01' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2025-01-01', '2026-01-01']);
+  })
+
+  it('2024-01-01부터 2년마다 같은 날짜에 반복되는 일정은 2024-01-01, 2026-01-01, 2028-01-01에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '2년마다 같은 날짜 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'yearly', interval: 2, endDate: '2028-01-01' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(3);
+    expect(result.map((e) => e.date)).toEqual(['2024-01-01', '2026-01-01', '2028-01-01']);
+  })
+
+  it('2024-02-29부터 1년마다 같은 날짜에 반복되는 일정은 2024-02-29, 2028-02-29에 동일한 일정이 있다.', () => {
+    const event: Event = {
+      id: '1',
+      title: '매년마다 반복 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-02-29',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'yearly', interval: 1, endDate: '2028-02-29' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.date)).toEqual(['2024-02-29', '2028-02-29']);
+  })
+})
+
+// 6단계: 예외 상황 처리
+// 요구사항 6.1 - 간격이 0인 경우
+
+// 반복 간격이 0이라면 무한 루프에 빠질 수 있습니다
+// 이런 경우 반복하지 않고 원본 이벤트 하나만 반환해야 합니다
+
+describe('예외 상황 처리', () => {
+  it('반복 간격이 0인 경우, 기존에 이벤트 하나만 반환된다.',() => {
+    const event: Event = {
+      id: '1',
+      title: '반복 간격이 0인 이벤트',
+      startTime: '10:00',
+      endTime: '11:00',
+      date: '2024-01-01',
+      description: '테스트 이벤트',
+      location: '온라인',
+      category: '회의',
+      repeat: { type: 'yearly', interval: 0, endDate: '2024-12-31' },
+      notificationTime: 15,
+    };
+    const result = generateRepeatEvents(event);
+    expect(result).toHaveLength(1);
+    expect(result).toEqual([event]);
+  })
+})

--- a/src/hooks/useEventOperations.ts
+++ b/src/hooks/useEventOperations.ts
@@ -69,6 +69,11 @@ export const useEventOperations = (editing: boolean, onSave?: () => void) => {
     }
   };
 
+  // 반복 이벤트 생성 로직
+  const createRepeatEvent = async () => {
+    return;
+  };
+
   async function init() {
     await fetchEvents();
     enqueueSnackbar('일정 로딩 완료!', { variant: 'info' });
@@ -79,5 +84,5 @@ export const useEventOperations = (editing: boolean, onSave?: () => void) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { events, fetchEvents, saveEvent, deleteEvent };
+  return { events, fetchEvents, saveEvent, deleteEvent, createRepeatEvent };
 };

--- a/src/utils/generateRepeatEvents.ts
+++ b/src/utils/generateRepeatEvents.ts
@@ -1,0 +1,5 @@
+import { Event } from '../types';
+
+export const generateRepeatEvents = (event: Event) => {
+  return;
+};

--- a/src/utils/generateRepeatEvents.ts
+++ b/src/utils/generateRepeatEvents.ts
@@ -1,5 +1,74 @@
-import { Event } from '../types';
+import { EventForm } from '../types';
+import { formatDate } from './dateUtils';
 
-export const generateRepeatEvents = (event: Event) => {
-  return;
+export const generateRepeatEvents = (event: EventForm) => {
+  const events: EventForm[] = [];
+  const startDate = new Date(event.date);
+  const repeatType = event.repeat.type;
+  const interval = event.repeat.interval;
+  const endDate = event.repeat.endDate ? new Date(event.repeat.endDate) : new Date('2024-06-30');
+
+  // 원본 날짜를 알고 있어야 월간 반복시 31일이나 예외 날짜일 경우 정상적으로 처리 가능
+  const originalDay = startDate.getDate();
+  const originalMonth = startDate.getMonth();
+
+  let currentDate = new Date(startDate);
+
+  // 반복 유형이 none이거나 repeat이 0인 경우 원본 이벤트만 반환
+  if (repeatType === 'none' || interval === 0) {
+    return [event];
+  }
+
+  // 반복 이벤트 생성 로직
+  while (currentDate <= endDate) {
+    events.push({
+      ...event,
+      date: formatDate(currentDate),
+    });
+
+    // repeatType에 따라 날짜 증가 로직 추가
+    switch (repeatType) {
+      case 'daily':
+        currentDate.setDate(currentDate.getDate() + interval);
+        break;
+
+      case 'weekly':
+        currentDate.setDate(currentDate.getDate() + 7 * interval);
+        break;
+
+      case 'monthly':
+        currentDate.setMonth(currentDate.getMonth() + interval);
+        currentDate.setDate(originalDay); // 월 변경 후 원래 날짜로 설정
+
+        // 날짜가 변경된 경우 (예: 31일에서 월 반복시 -> 30일, 29일, 28일이 될수 있음)
+        if (currentDate.getDate() !== originalDay) {
+          currentDate.setDate(1); // 1일로 초기화
+          currentDate.setMonth(currentDate.getMonth() + 1); // 다음 달로 이동
+        }
+        break;
+
+      case 'yearly':
+        // 년도 먼저 변경 후 나머지 설정
+        if (originalDay === 29 && originalMonth === 1) {
+          // 윤년은 4년마다 돌아온다
+          currentDate.setFullYear(currentDate.getFullYear() + 4);
+        } else {
+          // 아닌 달은 년도만 더해준다.
+          currentDate.setFullYear(currentDate.getFullYear() + interval);
+        }
+
+        currentDate.setDate(originalDay);
+        currentDate.setMonth(originalMonth);
+
+        // 년마다 반복시켜서 설정된 날짜나 달이 기존 값이랑 다를때 초기화시킴
+        if (currentDate.getDate() !== originalDay || currentDate.getMonth() !== originalMonth) {
+          currentDate.setDate(1);
+          currentDate.setMonth(0);
+          currentDate.setFullYear(currentDate.getFullYear() + 1);
+        }
+        break;
+    }
+  }
+
+  return events; // 기본 구현: 원본 이벤트만 반환
 };


### PR DESCRIPTION
# 회고

## 이번 복기 목표

3-2진행시 풀 AI를 활용했다보니 이번엔 수기로 작성하자고 다짐했습니다.
코드의 형태는 이해하고 있으나 어떤 기획적인(기능 설계) 부분을 더 고려해야할지 몰라 이번엔 직접 작성하면서 이해안되는 부분만 AI의 도움을 받으려고해요.

솔루션 코드를 분석하면서 이해안되는 부분은 이해하고 넘어가려고 노력했습니다.

---

# 기능 구현

## 반복 일정

### RED 사이클

우선 레드 사이클을 돌리기위해 신규 반복 이벤트를 인자로 받는 `generateRepeatEvents`를 만들었어요.

```js
export const generateRepeatEvents = (event: EventForm) => {
  return;
}
```

클로드에게 솔루션 코드를 기준으로 어떤 부분을 구현해야하는지 정리해달라고 했어요.
이 부분을 참고하여 테스트 코드를 실행한 상태로 하나씩 추가했고 레드 사이클을 진행했습니다.
테스트 코드에서 고려해야할 부분은 생각보다 단순했어요.

1. repeat 객체에서 type과 internal, endDate 기준으로 반복 여부 확인
2. 예외처리 생각하여 진행 (윤년, 말일 등등)
3. 복잡하게 생각히 말고 반복시 해당 이벤트가 생성되는지에 집중

<img width="200" height="699" alt="image" src="https://github.com/user-attachments/assets/d4068eac-ecdb-4e83-89ba-f44b9c4983ca" />
<img width="200" height="784" alt="image" src="https://github.com/user-attachments/assets/46062631-d0d1-4893-b14c-1081d19a05f8" />
<img width="200" height="646" alt="image" src="https://github.com/user-attachments/assets/185d1972-f014-4c55-a782-0e731c1546bf" />


### GREEN 사이클

솔루션 코드 중에 이해가 잘 안되는 코드가 있어서 더 쉽게 이해되는 코드로 작성했습니다.
어차피 `cureentDate`가 Date 객체형태여서 내부 메서드를 활용했어요.

```js
 // solution
 case 'daily':
        currentDate = new Date(
          currentDate.getTime() + eventData.repeat.interval * 24 * 60 * 60 * 1000
        );
        break;

// to-be
case 'daily':
        currentDate.setDate(currentDate.getDate() + interval);
        break;
```

코드 작성하면서 또 궁금점이 생겼는데 originalDay랑 originalMonth를 설정하는 이유가 궁금해졌어요.
단순히 getDate, getMonth를 사용하면 되는거 아닌가? 했는데 예외처리를 생각하지 못했네요.
1월 31일인 경우 한달 주기로 반복한다면 2월 31일이어야하는데 2월은 31일이 없죠, 그러니 마지막날인 28일은 건너뛰고 3월 31일, 5월 31일을 반환해야해요.
그래서 originalDay인 31일이 필요합니다. 두번째 달 반복시 2월 31일은 3월 2일로 변경되거든요. 그러면 다음 달부터 day는 2일로 고정되요.

